### PR TITLE
Use q to exit macrostep

### DIFF
--- a/layers/+lang/emacs-lisp/packages.el
+++ b/layers/+lang/emacs-lisp/packages.el
@@ -103,6 +103,7 @@
     :mode ("\\*.el\\'" . emacs-lisp-mode)
     :init
     (progn
+      (evil-define-key 'normal macrostep-keymap "q" 'macrostep-collapse-all)
       (spacemacs|define-micro-state macrostep
         :doc "[e] expand [c] collapse [n/N] next/previous [q] quit"
         :disable-evil-leader t


### PR DESCRIPTION
If `macrostep-mode` is entered separate of micro-state, there is no
normal mode mapping that will exit it.
